### PR TITLE
Refactor shape when including options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,19 @@
 import { GraphQLClient } from "graphql-request";
 import {
   AddressQuery,
-  AddressQueryVariables,
   getSdk,
   TokenMetadataRefreshMutation,
-  TokenMetadataRefreshMutationVariables,
   TokenQuery,
-  TokenQueryVariables,
   TokensQuery,
-  TokensQueryVariables,
   TokenTransfersQuery,
-  TokenTransfersQueryVariables,
 } from "./sdk";
+import {
+  AddressQueryOptions,
+  TokenQueryOptions,
+  TokensQueryOptions,
+  TokenTransfersQueryOptions,
+  TokenVariables,
+} from "./types";
 
 const DEFAULT_ENDPOINT = "https://api.basement.dev/graphiql";
 
@@ -24,22 +26,16 @@ export class SDK {
 
   /**
    * Queries information about an address
-   * @param {AddressQueryVariables} queryObj query variables object
-   * @param queryObj.name hex-address or ENS address
-   * @param queryObj.filterSuspectedScams *Experimental* - Whether to remove the results that are suspected to be scams - defaults to `false`
-   * @param queryObj.includeProfile Whether to include the ENS profile information in the response - defaults to `false`
-   * @param queryObj.includeReverseProfile Whether to include the reverse resolution of the ENS profile information in the response (ENS docs: https://docs.ens.domains/contract-api-reference/reverseregistrar) - defaults to `false`
-   * @param queryObj.includeTokens Whether to include the tokens that the address holds - defaults to `false`
-   * @param queryObj.tokensLimit Maximum number of tokens to return. `queryObj.includeTokens` must be set to `true` for this option to take effect - defaults to `10`
    */
   public async address({
     name,
-    filterSuspectedScams,
-    includeProfile,
-    includeReverseProfile,
-    includeTokens,
-    tokensLimit = 10,
-  }: AddressQueryVariables): Promise<AddressQuery> {
+    include,
+  }: AddressQueryOptions): Promise<AddressQuery> {
+    const includeTokens = !!include?.tokens;
+    const tokensLimit = include?.tokens?.limit;
+    const filterSuspectedScams = include?.tokens?.filterSuspectedScams;
+    const includeProfile = include?.profile;
+    const includeReverseProfile = include?.reverseProfile;
     return this.sdk.address({
       name,
       filterSuspectedScams,
@@ -52,24 +48,20 @@ export class SDK {
 
   /**
    * Queries information about a specific token
-   * @param {TokenQueryVariables} queryObj query variables object
-   * @param queryObj.contract contract hex-address
-   * @param queryObj.id internal ID
-   * @param queryObj.tokenId token ID
-   * @param queryObj.includeOwnerProfile Whether to include the owner's profile in the response -  defaults to `false`
-   * @param queryObj.includeOwnerReverseProfile Whether to include the owner's ENS reverse resolution profile in the response - defaults to `false`
    */
   public async token({
     contract,
     id,
-    includeOwnerProfile,
-    includeOwnerReverseProfile,
     tokenId,
-  }: Omit<TokenQueryVariables, "includeOwnerInfo">): Promise<TokenQuery> {
+    include,
+  }: TokenQueryOptions): Promise<TokenQuery> {
+    const includeOwnerInfo = !!include?.owner;
+    const includeOwnerProfile = include?.owner?.profile;
+    const includeOwnerReverseProfile = include?.owner?.reverseProfile;
     return this.sdk.token({
       contract,
       id,
-      includeOwnerInfo: includeOwnerProfile || includeOwnerReverseProfile,
+      includeOwnerInfo,
       includeOwnerProfile,
       includeOwnerReverseProfile,
       tokenId,
@@ -78,16 +70,12 @@ export class SDK {
 
   /**
    * Refreshes metadata of a specific token
-   * @param {TokenMetadataRefreshMutationVariables} mutationObj mutation variables object
-   * @param mutationObj.contract contract hex-address
-   * @param mutationObj.id internal ID
-   * @param mutationObj.tokenId token ID
    */
   public async tokenMetadataRefresh({
     contract,
     id,
     tokenId,
-  }: TokenMetadataRefreshMutationVariables): Promise<TokenMetadataRefreshMutation> {
+  }: TokenVariables): Promise<TokenMetadataRefreshMutation> {
     return this.sdk.tokenMetadataRefresh({
       contract,
       id,
@@ -97,24 +85,20 @@ export class SDK {
 
   /**
    * Query tokens that satisfy the given filter(s)
-   * @param {TokensQueryVariables} queryObj query variables object
-   * @param queryObj.filter.contractAddress Filter tokens that satisfy the given contract address
-   * @param queryObj.includeOwnerProfile Whether to include the owner's profile in the response -  defaults to `false`
-   * @param queryObj.includeOwnerReverseProfile Whether to include the owner's ENS reverse resolution profile in the response - defaults to `false`
-   * @param queryObj.limit Maximum number of tokens to return - defaults to `10`
-   * @param queryObj.cursor Cursor used for pagination. To go the next page, provide the given cursor from the response
    */
   public async tokens({
     filter,
     cursor,
-    includeOwnerProfile,
-    includeOwnerReverseProfile,
+    include,
     limit = 10,
-  }: Omit<TokensQueryVariables, "includeOwnerInfo">): Promise<TokensQuery> {
+  }: TokensQueryOptions): Promise<TokensQuery> {
+    const includeOwnerInfo = !!include?.owner;
+    const includeOwnerProfile = include?.owner?.profile;
+    const includeOwnerReverseProfile = include?.owner?.reverseProfile;
     return this.sdk.tokens({
       filter,
       cursor,
-      includeOwnerInfo: includeOwnerProfile || includeOwnerReverseProfile,
+      includeOwnerInfo,
       includeOwnerProfile,
       includeOwnerReverseProfile,
       limit,
@@ -123,30 +107,26 @@ export class SDK {
 
   /**
    * Query token transfers that satisfy the given filter(s)
-   * @param {TokenTransfersQueryVariables} queryObj query variables object
-   * @param queryObj.filter.contractAddress Filter tokens that satisfy the given contract address
-   * @param queryObj.limit Maximum number of token transfers to return - defaults to `10`
-   * @param queryObj.cursor Cursor used for pagination. To go the next page, provide the given cursor from the response
-   * @param queryObj.includeERC721Metadata Whether to include ERC721 metadata, like `tokenId`, `attributes`, `contractAddress`, etc - defaults to `false`
-   * @param queryObj.includeFromProfile Whether to include the `from` profile in the response. This option is not needed if you need to only retrieve the `from` address -  defaults to `false`
-   * @param queryObj.includeFromReverseProfile Whether to include the `from` ENS reverse resolution profile in the response - defaults to `false`
-   * @param queryObj.includeFromTokensInfo Whether to include `from` tokens information (This function returns a maximum of 10 tokens, if you need to get a more comprehensive response, use the `tokens` function) - defaults to `false`
-   * @param queryObj.includeToProfile Whether to include the `to` profile in the response. This option is not needed if you need to only retrieve the `to` address -  defaults to `false`
-   * @param queryObj.includeToReverseProfile Whether to include the `to` ENS reverse resolution profile in the response - defaults to `false`
-   * @param queryObj.includeToTokensInfo Whether to include `to` token information (This function returns a maximum of 10 tokens, if you need to get a more comprehensive response, use the `tokens` function) - defaults to `false`
    */
   public async tokenTransfers({
     filter,
     cursor,
-    includeERC721Metadata,
-    includeFromProfile,
-    includeFromReverseProfile,
-    includeFromTokensInfo,
-    includeToProfile,
-    includeToReverseProfile,
-    includeToTokensInfo,
-    limit,
-  }: TokenTransfersQueryVariables): Promise<TokenTransfersQuery> {
+    include,
+    limit = 10,
+  }: TokenTransfersQueryOptions): Promise<TokenTransfersQuery> {
+    const includeERC721Metadata = include?.erc721Metadata;
+    const includeFromProfile = include?.from?.profile;
+    const includeFromReverseProfile = include?.from?.reverseProfile;
+    const includeFromTokensInfo = !!include?.from?.tokens;
+    const fromTokensFilterSuspectedScam =
+      include?.from?.tokens?.filterSuspectedScams;
+    const fromTokensLimit = include?.from?.tokens?.limit;
+    const includeToProfile = include?.to?.profile;
+    const includeToReverseProfile = include?.to?.reverseProfile;
+    const includeToTokensInfo = !!include?.to?.tokens;
+    const toTokensFilterSuspectedScam =
+      include?.to?.tokens?.filterSuspectedScams;
+    const toTokensLimit = include?.to?.tokens?.limit;
     return this.sdk.tokenTransfers({
       filter,
       cursor,
@@ -154,9 +134,13 @@ export class SDK {
       includeFromProfile,
       includeFromReverseProfile,
       includeFromTokensInfo,
+      fromTokensFilterSuspectedScam,
+      fromTokensLimit,
       includeToProfile,
       includeToReverseProfile,
       includeToTokensInfo,
+      toTokensLimit,
+      toTokensFilterSuspectedScam,
       limit,
     });
   }

--- a/src/queries.graphql
+++ b/src/queries.graphql
@@ -63,10 +63,14 @@ query tokenTransfers(
   $includeERC721Metadata: Boolean = false
   $includeFromProfile: Boolean = false
   $includeFromReverseProfile: Boolean = false
+  $includeFromTokensInfo: Boolean = false
+  $fromTokensLimit: Int = 10
+  $fromTokensFilterSuspectedScam: Boolean = false
   $includeToProfile: Boolean = false
   $includeToReverseProfile: Boolean = false
-  $includeFromTokensInfo: Boolean = false
   $includeToTokensInfo: Boolean = false
+  $toTokensLimit: Int = 10
+  $toTokensFilterSuspectedScam: Boolean = false
 ) {
   tokenTransfers(filter: $filter, limit: $limit, cursor: $cursor) {
     nextCursor
@@ -88,7 +92,10 @@ query tokenTransfers(
           ...CommonServiceKeys
           ...GlobalKeys
         }
-        tokens @include(if: $includeFromTokensInfo) {
+        tokens(
+          limit: $fromTokensLimit
+          filter: { filterSuspectedScams: $fromTokensFilterSuspectedScam }
+        ) @include(if: $includeFromTokensInfo) {
           ...TokenInfo
         }
       }
@@ -102,7 +109,10 @@ query tokenTransfers(
           ...CommonServiceKeys
           ...GlobalKeys
         }
-        tokens @include(if: $includeToTokensInfo) {
+        tokens(
+          limit: $toTokensLimit
+          filter: { filterSuspectedScams: $toTokensFilterSuspectedScam }
+        ) @include(if: $includeToTokensInfo) {
           ...TokenInfo
         }
       }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -337,10 +337,14 @@ export const TokenTransfersDocument = gql`
     $includeERC721Metadata: Boolean = false
     $includeFromProfile: Boolean = false
     $includeFromReverseProfile: Boolean = false
+    $includeFromTokensInfo: Boolean = false
+    $fromTokensLimit: Int = 10
+    $fromTokensFilterSuspectedScam: Boolean = false
     $includeToProfile: Boolean = false
     $includeToReverseProfile: Boolean = false
-    $includeFromTokensInfo: Boolean = false
     $includeToTokensInfo: Boolean = false
+    $toTokensLimit: Int = 10
+    $toTokensFilterSuspectedScam: Boolean = false
   ) {
     tokenTransfers(filter: $filter, limit: $limit, cursor: $cursor) {
       nextCursor
@@ -362,7 +366,10 @@ export const TokenTransfersDocument = gql`
             ...CommonServiceKeys
             ...GlobalKeys
           }
-          tokens @include(if: $includeFromTokensInfo) {
+          tokens(
+            limit: $fromTokensLimit
+            filter: { filterSuspectedScams: $fromTokensFilterSuspectedScam }
+          ) @include(if: $includeFromTokensInfo) {
             ...TokenInfo
           }
         }
@@ -376,7 +383,10 @@ export const TokenTransfersDocument = gql`
             ...CommonServiceKeys
             ...GlobalKeys
           }
-          tokens @include(if: $includeToTokensInfo) {
+          tokens(
+            limit: $toTokensLimit
+            filter: { filterSuspectedScams: $toTokensFilterSuspectedScam }
+          ) @include(if: $includeToTokensInfo) {
             ...TokenInfo
           }
         }
@@ -746,10 +756,14 @@ export type TokenTransfersQueryVariables = Exact<{
   includeERC721Metadata?: InputMaybe<Scalars["Boolean"]>;
   includeFromProfile?: InputMaybe<Scalars["Boolean"]>;
   includeFromReverseProfile?: InputMaybe<Scalars["Boolean"]>;
+  includeFromTokensInfo?: InputMaybe<Scalars["Boolean"]>;
+  fromTokensLimit?: InputMaybe<Scalars["Int"]>;
+  fromTokensFilterSuspectedScam?: InputMaybe<Scalars["Boolean"]>;
   includeToProfile?: InputMaybe<Scalars["Boolean"]>;
   includeToReverseProfile?: InputMaybe<Scalars["Boolean"]>;
-  includeFromTokensInfo?: InputMaybe<Scalars["Boolean"]>;
   includeToTokensInfo?: InputMaybe<Scalars["Boolean"]>;
+  toTokensLimit?: InputMaybe<Scalars["Int"]>;
+  toTokensFilterSuspectedScam?: InputMaybe<Scalars["Boolean"]>;
 }>;
 
 export type TokenTransfersQuery = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,84 @@
+export type TokenFilterOptions = {
+  /** Maximum number of tokens to return  - defaults to `10`  */
+  limit?: number;
+  /** *Experimental* - Whether to remove the results that are suspected to be scams - defaults to `false` */
+  filterSuspectedScams?: boolean;
+};
+
+export type TokensIncludeOption = {
+  /** Whether to include the tokens that the address holds - defaults to `false` */
+  tokens?: TokenFilterOptions;
+};
+
+export type AddressQueryIncludeOptions = TokensIncludeOption & OwnerOptions;
+
+export type AddressQueryOptions = {
+  /** hex-address or ENS address */
+  name: string;
+  /** Includes more data in the response */
+  include?: AddressQueryIncludeOptions;
+};
+
+export type OwnerOptions = {
+  /** Whether to include the ENS profile information in the response - defaults to `false` */
+  profile?: boolean;
+  /** Whether to include the reverse resolution of the ENS profile information in the response (ENS docs: https://docs.ens.domains/contract-api-reference/reverseregistrar) - defaults to `false`  */
+  reverseProfile?: boolean;
+};
+
+export type TokenQueryIncludeOptions = {
+  /** Whether to include owner's information in the response. Having an empty `owner` object will only return the `owner`'s address */
+  owner?: OwnerOptions;
+};
+
+export type TokenVariables = {
+  /** contract hex-address */
+  contract: string;
+  /** token ID */
+  tokenId?: string;
+  /** internal ID */
+  id?: number;
+};
+
+export type TokenQueryBaseOptions = {
+  /** Includes more data in the response */
+  include?: TokenQueryIncludeOptions;
+};
+
+export type TokenQueryOptions = TokenQueryBaseOptions & TokenVariables;
+
+export type TokensQueryFilterOptions = {
+  /** Filter tokens that satisfy the given contract address */
+  contractAddress: string;
+};
+
+export type TokensQueryOptions = TokenQueryBaseOptions & {
+  /** Filter option(s) */
+  filter: TokensQueryFilterOptions;
+  /** Cursor used for pagination. To go the next page, provide the given cursor from the response */
+  cursor?: string;
+  /** Maximum number of tokens to return - defaults to `10` */
+  limit?: number;
+};
+
+export type TokenTransfersQueryFilterOptions = TokensQueryFilterOptions;
+
+export type TokenTransfersQueryIncludeOptions = {
+  /** Whether to include ERC721 metadata, like `tokenId`, `attributes`, `contractAddress`, etc - defaults to `false` */
+  erc721Metadata?: boolean;
+  /** Whether to include from's information in the response. Having an empty `from` object will only return the `from`'s address */
+  from?: OwnerOptions & TokensIncludeOption;
+  /** Whether to include to's information in the response. Having an empty `to` object will only return the `to`'s address */
+  to?: OwnerOptions & TokensIncludeOption;
+};
+
+export type TokenTransfersQueryOptions = {
+  /** Filter option(s) */
+  filter: TokenTransfersQueryFilterOptions;
+  /** Cursor used for pagination. To go the next page, provide the given cursor from the response */
+  cursor?: string;
+  /** Maximum number of token transfers to return - defaults to `10` */
+  limit?: number;
+  /** Includes more data in the response */
+  include?: TokenTransfersQueryIncludeOptions;
+};

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,10 +7,14 @@ describe("Basement SDK", () => {
 
   test("token query", async () => {
     const { token } = await sdk.token({
-      includeOwnerProfile: true,
-      includeOwnerReverseProfile: true,
       contract: TOKEN_CONTRACT_ADDRESS,
       tokenId: TOKEN_ID,
+      include: {
+        owner: {
+          profile: true,
+          reverseProfile: true,
+        },
+      },
     });
 
     const keys = Object.keys(token.ownerAddress);
@@ -24,10 +28,11 @@ describe("Basement SDK", () => {
     const tokensLimit = 15;
     const { address } = await sdk.address({
       name: "test.eth",
-      includeProfile: true,
-      includeReverseProfile: true,
-      includeTokens: true,
-      tokensLimit,
+      include: {
+        profile: true,
+        reverseProfile: true,
+        tokens: { filterSuspectedScams: true, limit: 10 },
+      },
     });
 
     const keys = Object.keys(address);
@@ -51,11 +56,14 @@ describe("Basement SDK", () => {
     const tokensLimit = 5;
     const { tokens } = await sdk.tokens({
       filter: { contractAddress: TOKEN_CONTRACT_ADDRESS },
-      includeOwnerProfile: true,
-      includeOwnerReverseProfile: true,
       limit: tokensLimit,
+      include: {
+        owner: {
+          profile: true,
+          reverseProfile: true,
+        },
+      },
     });
-
     expect(tokens?.tokens?.length).toBeLessThanOrEqual(tokensLimit);
     const token = tokens?.tokens[0];
     const keys = Object.keys(token?.ownerAddress);
@@ -69,13 +77,19 @@ describe("Basement SDK", () => {
     const { tokenTransfers } = await sdk.tokenTransfers({
       filter: { contractAddress: TOKEN_CONTRACT_ADDRESS },
       limit: tokenTransfersLimit,
-      includeERC721Metadata: true,
-      includeFromProfile: true,
-      includeFromReverseProfile: true,
-      includeFromTokensInfo: true,
-      includeToProfile: true,
-      includeToReverseProfile: true,
-      includeToTokensInfo: true,
+      include: {
+        erc721Metadata: true,
+        from: {
+          profile: true,
+          reverseProfile: true,
+          tokens: {},
+        },
+        to: {
+          profile: true,
+          reverseProfile: true,
+          tokens: {},
+        },
+      },
     });
 
     const tokenTransfer = tokenTransfers?.tokenTransfers[0];


### PR DESCRIPTION
Previously, when including options in the response, the API looked like this:

```typescript
const { token } = await sdk.token({
  contract: string,
  tokenId: string,
  includeOwnerProfile: boolean,
  includeOwnerReverseProfile: boolean
})
```

Now, it's refactored to have the following shape:

```typescript
const { token } = await sdk.token({
  contract: string,
  tokenId: string,
  include: {
      owner: {
      profile: boolean,
      reverseProfile: boolean
    }
  }
})
```
JSDoc has also been added to each property as opposed to the function, which provides a better developer experience