### PR TITLE
Change url from /v2/graphiql to /v2/graphql

### DIFF
--- a/src/basement.ts
+++ b/src/basement.ts
@@ -24,7 +24,7 @@ import {
   parseTransactionIncludeOptions,
 } from "./utils/parseIncludeOptions";
 
-export const DEFAULT_ENDPOINT = "https://beta.basement.dev/v2/graphiql";
+export const DEFAULT_ENDPOINT = "https://beta.basement.dev/v2/graphql";
 
 type SDKOptions = {
   endpoint?: string;


### PR DESCRIPTION
`/graphiql` hosts the playground and has different behavior based on the request, whereas `/graphql` always acts like a graphql API.